### PR TITLE
Workaround for "PRESS START BUTTON" crash

### DIFF
--- a/d3d9.cpp
+++ b/d3d9.cpp
@@ -4,14 +4,23 @@
 #include "main.h"
 #include "Settings.h"
 
+namespace {
+	/* Direct3DCreate9 seems to be called twice when the game first launches, and then again every single time 
+	   a video plays. For some reason, Steam's GameOverlayRenderer.dll (which performs its own hooking of
+	   Direct3DCreate9 among other things) crashes when videos play. We only need the hook when the game first
+	   launches anyway, so only create hkIDirect3D9s twice to work around that crash. */
+	int hkDirect3DCreate9CallCount = 0;
+}
+
 IDirect3D9 *APIENTRY hkDirect3DCreate9(UINT SDKVersion) {
 	IDirect3D9 *d3dint = NULL;
 	//if(Settings::get().getEnableTripleBuffering()) Direct3DCreate9Ex(SDKVersion, (IDirect3D9Ex**)&d3dint);
 	//else d3dint = oDirect3DCreate9(SDKVersion);
 	d3dint = oDirect3DCreate9(SDKVersion);
 
-	if(d3dint != NULL) {
+	if(d3dint != NULL && hkDirect3DCreate9CallCount < 2) {
 		hkIDirect3D9 *ret = new hkIDirect3D9(&d3dint);
+		++hkDirect3DCreate9CallCount;
 	}
 	return d3dint;
 }


### PR DESCRIPTION
I get the same issue as PeterTh/dsfix#14 and solved it by only hooking the `IDirect3D9` interface for the first two calls to Direct3DCreate9, which occur when the game starts up. It seems to be called every time a video plays as well (which happens with the DARK SOULS logo at the PRESS START screen, among other times) and for some people including myself, without this fix preventing it, GameOverlayRenderer.dll causes the game to crash.

I've been using this for a while and have encountered no extra problems. It's strange that it only occurs for some people, but this is a simple workaround that seems to totally fix it for me.