### PR TITLE
HD texture override fix, prefetch option; Steam save fix

### DIFF
--- a/DATA/DSfix.ini
+++ b/DATA/DSfix.ini
@@ -192,6 +192,11 @@ enableTextureDumping 0
 # will cause a small slowdown during texture loading!
 enableTextureOverride 0
 
+# enables texture prefetch if texture override is turned on
+# textures will be preloaded into memory at startup
+# no disk overhead when loading them when entering new area (little performance boost)
+enableTexturePrefetch 0
+
 ###############################################################################
 # Other Options
 ###############################################################################

--- a/RenderstateManager.cpp
+++ b/RenderstateManager.cpp
@@ -757,45 +757,7 @@ HRESULT RSManager::redirectD3DXCreateTextureFromFileInMemoryEx(LPDIRECT3DDEVICE9
         if (Settings::get().getEnableTexturePrefetch() && cachedTexFiles.find(hash) != cachedTexFiles.end())
         {
             SDLOG(0, "Cached texture file found! size: %ld, hash: %8x \n", cachedTexFiles[hash].size, hash);
-            HRESULT ret;
-            // delete comments to check the running times of different methods
-            //double startTime;
-            /*D3DXIMAGE_INFO imageInfo;
-            D3DXGetImageInfoFromFileInMemory(cachedTexFiles[hash].buffer, cachedTexFiles[hash].size, &imageInfo);
-            SDLOG(0, "file info: Width %u, Height %u, Depth %u, MipLevels %u, Format %d, ResourceType %d, ImageFileFormat %d \n", 
-                imageInfo.Width, imageInfo.Height, imageInfo.Depth, imageInfo.MipLevels, imageInfo.Format, imageInfo.ResourceType, imageInfo.ImageFileFormat);
-            SDLOG(0, "requested: Width %u, Height %u, MipLevels %u, Format %d, Pool: %d D3DX_DEFAULT %u\n",
-                Width, Height, MipLevels, Format, Pool, D3DX_DEFAULT);
-            char buffer[128];
-            startTime = getElapsedTime();
-            sprintf_s(buffer, "dsfix/tex_override/%08x.png", hash);
-            if (fileExists(buffer)) {
-                ret = D3DXCreateTextureFromFileEx(pDevice, buffer, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, Format, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
-            }
-            sprintf_s(buffer, "dsfix/tex_override/%08x.dds", hash);
-            if (fileExists(buffer)) {
-                ret = D3DXCreateTextureFromFileEx(pDevice, buffer, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, Format, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
-            }
-            SDLOG(0, "From disk returned: %08lx time: %f\n", ret, getElapsedTime() - startTime);
-
-            startTime = getElapsedTime();
-            sprintf_s(buffer, "dsfix/tex_override/%08x.png", hash);
-            if (fileExists(buffer)) {
-                ret = D3DXCreateTextureFromFileEx(pDevice, buffer, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, D3DFMT_FROM_FILE, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
-            }
-            sprintf_s(buffer, "dsfix/tex_override/%08x.dds", hash);
-            if (fileExists(buffer)) {
-                ret = D3DXCreateTextureFromFileEx(pDevice, buffer, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, D3DFMT_FROM_FILE, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
-            }
-            SDLOG(0, "From disk returned with file format matching: %08lx time: %f\n", ret, getElapsedTime() - startTime);
-
-            startTime = getElapsedTime();
-            ret = TrueD3DXCreateTextureFromFileInMemoryEx(pDevice, cachedTexFiles[hash].buffer, cachedTexFiles[hash].size, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, Format, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
-            SDLOG(0, "From memory returned: %08lx time: %f\n", ret, getElapsedTime() - startTime);*/
-            //startTime = getElapsedTime();
-            ret = TrueD3DXCreateTextureFromFileInMemoryEx(pDevice, cachedTexFiles[hash].buffer, cachedTexFiles[hash].size, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, D3DFMT_FROM_FILE, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
-            //SDLOG(0, "From memory with file format matching returned: %08lx time: %f\n", ret, getElapsedTime() - startTime);
-            return ret;
+            return TrueD3DXCreateTextureFromFileInMemoryEx(pDevice, cachedTexFiles[hash].buffer, cachedTexFiles[hash].size, D3DX_DEFAULT, D3DX_DEFAULT, MipLevels, Usage, D3DFMT_FROM_FILE, Pool, Filter, MipFilter, ColorKey, pSrcInfo, pPalette, ppTexture);
         }
         else
         {

--- a/RenderstateManager.h
+++ b/RenderstateManager.h
@@ -105,6 +105,17 @@ class RSManager {
 	IDirect3DTexture9* prevRenderTex;
 	IDirect3DStateBlock9* prevStateBlock;
 
+    struct MemData
+    {
+        char* buffer;
+        long size;
+    };
+    
+    std::map<UINT32, MemData> cachedTexFiles;
+
+private:
+    ~RSManager();
+
 public:
 	static RSManager& get() {
 		return instance;
@@ -122,6 +133,7 @@ public:
 
 	void initResources();
 	void releaseResources();
+    void prefetchTextures();
 
 	void setViewport(const D3DVIEWPORT9& vp) {
 		viewport = vp;

--- a/SaveManager.cpp
+++ b/SaveManager.cpp
@@ -24,9 +24,16 @@ void SaveManager::init() {
 		HANDLE searchHandle = FindFirstFile(buffer, &userSaveFolderData);
 		bool found = false;
 		if(searchHandle != INVALID_HANDLE_VALUE) {
-			do {
-				if(strlen(userSaveFolderData.cFileName)>2) {
-					sprintf_s(buffer, "%s%s%s", documents, "\\NBGI\\DarkSouls\\", userSaveFolderData.cFileName);
+            do {
+                std::string fn = userSaveFolderData.cFileName;
+                bool dir = userSaveFolderData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY;
+                bool saveFile = fn.substr(fn.find_last_of(".") + 1) == "sl2";
+                // newer versions don't contain an additional folder under NBGI\\DarkSouls
+                if (fn.size() > 2 && (dir || saveFile)) {
+                    if (dir)
+					    sprintf_s(buffer, "%s%s%s", documents, "\\NBGI\\DarkSouls\\", userSaveFolderData.cFileName);
+                    else
+                        sprintf_s(buffer, "%s%s", documents, "\\NBGI\\DarkSouls");
 					userSaveFolder = string(buffer);
 					SDLOG(0, "SaveManager: user save folder is %s\n", userSaveFolder.c_str());
 					found = true;

--- a/Settings.def
+++ b/Settings.def
@@ -50,6 +50,7 @@ SETTING(std::string, ScreenshotDir, "screenshotDir", ".");
 // Texture Override Options
 SETTING(bool, EnableTextureDumping, "enableTextureDumping", false);
 SETTING(bool, EnableTextureOverride, "enableTextureOverride", false);
+SETTING(bool, EnableTexturePrefetch, "enableTexturePrefetch", false);
 
 // HUD options
 SETTING(bool, EnableHudMod, "enableHudMod", false)


### PR DESCRIPTION
Correct savefile finding with current Steam version of the game: Check if there is a directory under ~\Documents\NBGI\DarkSouls or there is the save file itself.
Prefetch option for override textures: Preloading textures into memory when initializing
HD textures stuttering fix: When textures was not in the requested format (eg. DXT5 vs DXT3) converting them did take a while; use the file format instead