### PR TITLE
HD texture override fix, prefetch option

### DIFF
--- a/DATA/DSfix.ini
+++ b/DATA/DSfix.ini
@@ -192,6 +192,11 @@ enableTextureDumping 0
 # will cause a small slowdown during texture loading!
 enableTextureOverride 0
 
+# enables texture prefetch if texture override is turned on
+# textures will be preloaded into memory at startup
+# no disk overhead when loading them when entering new area (little performance boost)
+enableTexturePrefetch 0
+
 ###############################################################################
 # Other Options
 ###############################################################################

--- a/RenderstateManager.h
+++ b/RenderstateManager.h
@@ -105,6 +105,17 @@ class RSManager {
 	IDirect3DTexture9* prevRenderTex;
 	IDirect3DStateBlock9* prevStateBlock;
 
+    struct MemData
+    {
+        char* buffer;
+        long size;
+    };
+    
+    std::map<UINT32, MemData> cachedTexFiles;
+
+private:
+    ~RSManager();
+
 public:
 	static RSManager& get() {
 		return instance;
@@ -122,6 +133,7 @@ public:
 
 	void initResources();
 	void releaseResources();
+    void prefetchTextures();
 
 	void setViewport(const D3DVIEWPORT9& vp) {
 		viewport = vp;

--- a/Settings.def
+++ b/Settings.def
@@ -50,6 +50,7 @@ SETTING(std::string, ScreenshotDir, "screenshotDir", ".");
 // Texture Override Options
 SETTING(bool, EnableTextureDumping, "enableTextureDumping", false);
 SETTING(bool, EnableTextureOverride, "enableTextureOverride", false);
+SETTING(bool, EnableTexturePrefetch, "enableTexturePrefetch", false);
 
 // HUD options
 SETTING(bool, EnableHudMod, "enableHudMod", false)


### PR DESCRIPTION
Prefetch option for override textures: Preloading textures into memory when initializing
HD textures stuttering fix: When textures was not in the requested format (eg. DXT5 vs DXT3) converting them did take a while; use the file format instead