### PR TITLE
Fix sun and lens flares

### DIFF
--- a/DSfix.vcxproj
+++ b/DSfix.vcxproj
@@ -251,6 +251,7 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">WIN32;NDEBUG;_WINDOWS;_MBCS;_USRDLL</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">WIN32;NDEBUG;_WINDOWS;_MBCS;_USRDLL</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="d3d9query.cpp" />
     <ClCompile Include="d3dutil.cpp" />
     <ClCompile Include="Detouring.cpp" />
     <ClCompile Include="dinputWrapper.cpp" />
@@ -313,6 +314,7 @@
   <ItemGroup>
     <ClInclude Include="AreaTex.h" />
     <ClInclude Include="d3d9.h" />
+    <ClInclude Include="d3d9query.h" />
     <ClInclude Include="d3dutil.h" />
     <ClInclude Include="Detouring.h" />
     <ClInclude Include="dinput.h" />

--- a/RenderstateManager.cpp
+++ b/RenderstateManager.cpp
@@ -34,6 +34,7 @@ namespace {
 void RSManager::initResources() {
 	SDLOG(0, "RenderstateManager resource initialization started\n");
 	unsigned rw = Settings::get().getRenderWidth(), rh = Settings::get().getRenderHeight();
+	areaScale = rw * rh / 1024.0 / 576.0;
 	unsigned dofRes = getDOFResolution();
 	if(Settings::get().getAAQuality()) {
 		if(Settings::get().getAAType() == "SMAA") {

--- a/RenderstateManager.cpp
+++ b/RenderstateManager.cpp
@@ -15,15 +15,26 @@
 
 RSManager RSManager::instance;
 
-static const char *PIXEL_SHADER_DUMP_DIR = "dsfix/pixelshader_dump";
-static const char *PIXEL_SHADER_OVERRIDE_DIR = "dsfix/pixelshader_override";
-static const char *VERTEX_SHADER_DUMP_DIR = "dsfix/vertexshader_dump";
-static const char *VERTEX_SHADER_OVERRIDE_DIR = "dsfix/vertexshader_override";
+namespace {
+	const char *PIXEL_SHADER_DUMP_DIR = "dsfix/pixelshader_dump";
+	const char *PIXEL_SHADER_OVERRIDE_DIR = "dsfix/pixelshader_override";
+	const char *VERTEX_SHADER_DUMP_DIR = "dsfix/vertexshader_dump";
+	const char *VERTEX_SHADER_OVERRIDE_DIR = "dsfix/vertexshader_override";
+
+	unsigned getDOFResolution() {
+		unsigned setting = Settings::get().getDOFOverrideResolution();
+		if (setting == 0) {
+			return 360;
+		} else {
+			return setting;
+		}
+	}
+}
 
 void RSManager::initResources() {
 	SDLOG(0, "RenderstateManager resource initialization started\n");
 	unsigned rw = Settings::get().getRenderWidth(), rh = Settings::get().getRenderHeight();
-	unsigned dofRes = Settings::get().getDOFOverrideResolution();
+	unsigned dofRes = getDOFResolution();
 	if(Settings::get().getAAQuality()) {
 		if(Settings::get().getAAType() == "SMAA") {
 			smaa = new SMAA(d3ddev, rw, rh, (SMAA::Preset)(Settings::get().getAAQuality()-1));
@@ -581,7 +592,7 @@ void RSManager::reloadScao() {
 
 void RSManager::reloadGauss() {
 	SAFEDELETE(gauss); 
-	gauss = new GAUSS(d3ddev, Settings::get().getDOFOverrideResolution()*16/9, Settings::get().getDOFOverrideResolution());
+	gauss = new GAUSS(d3ddev, getDOFResolution()*16/9, getDOFResolution());
 	SDLOG(0, "Reloaded GAUSS\n");
 }
 
@@ -754,7 +765,7 @@ bool RSManager::isTextureText(IDirect3DBaseTexture9* t) {
 }
 
 unsigned RSManager::isDof(unsigned width, unsigned height) {
-	unsigned topWidth = Settings::get().getDOFOverrideResolution()*16/9, topHeight = Settings::get().getDOFOverrideResolution();
+	unsigned topWidth = getDOFResolution()*16/9, topHeight = getDOFResolution();
 	if(width == topWidth && height == topHeight) return 1;
 	if(width == topWidth/2 && height == topHeight/2) return 2;
 	return 0;

--- a/RenderstateManager.h
+++ b/RenderstateManager.h
@@ -117,7 +117,11 @@ class RSManager {
 	void dumpShader(UINT32 hash, const char *directory, LPD3DXBUFFER pBuffer);
 	bool getOverrideShader(UINT32 hash, const char *directory, LPD3DXBUFFER *ppBuffer);
 
-	float areaScale;
+	bool haveOcclusionScale;
+	float occlusionScale;
+
+	void measureOcclusionScale();
+
 private:
     ~RSManager();
 
@@ -128,7 +132,7 @@ public:
 
 	RSManager() : smaa(NULL), fxaa(NULL), ssao(NULL), gauss(NULL), rgbaBuffer1Surf(NULL), rgbaBuffer1Tex(NULL),
 			inited(false), doAA(true), doSsao(true), doDofGauss(true), doHud(true), captureNextFrame(false), capturing(false), hudStarted(false), takeScreenshot(false), hideHud(false),
-			mainRenderTexIndex(0), mainRenderSurfIndex(0), dumpCaptureIndex(0), numKnownTextures(0), foundKnownTextures(0), skippedPresents(0), areaScale(1) {
+			mainRenderTexIndex(0), mainRenderSurfIndex(0), dumpCaptureIndex(0), numKnownTextures(0), foundKnownTextures(0), skippedPresents(0), haveOcclusionScale(false), occlusionScale(1) {
 		#define TEXTURE(_name, _hash) ++numKnownTextures;
 		#include "Textures.def"
 		#undef TEXTURE
@@ -197,5 +201,5 @@ public:
 	HRESULT redirectCreatePixelShader(CONST DWORD *pfunction, IDirect3DPixelShader9 **ppShader);
 	HRESULT redirectCreateVertexShader(CONST DWORD *pfunction, IDirect3DVertexShader9 **ppShader);
 
-	float getAreaScale() const { return areaScale; }
+	float getOcclusionScale() const { return occlusionScale; }
 };

--- a/RenderstateManager.h
+++ b/RenderstateManager.h
@@ -117,6 +117,7 @@ class RSManager {
 	void dumpShader(UINT32 hash, const char *directory, LPD3DXBUFFER pBuffer);
 	bool getOverrideShader(UINT32 hash, const char *directory, LPD3DXBUFFER *ppBuffer);
 
+	float areaScale;
 private:
     ~RSManager();
 
@@ -127,7 +128,7 @@ public:
 
 	RSManager() : smaa(NULL), fxaa(NULL), ssao(NULL), gauss(NULL), rgbaBuffer1Surf(NULL), rgbaBuffer1Tex(NULL),
 			inited(false), doAA(true), doSsao(true), doDofGauss(true), doHud(true), captureNextFrame(false), capturing(false), hudStarted(false), takeScreenshot(false), hideHud(false),
-			mainRenderTexIndex(0), mainRenderSurfIndex(0), dumpCaptureIndex(0), numKnownTextures(0), foundKnownTextures(0), skippedPresents(0) {
+			mainRenderTexIndex(0), mainRenderSurfIndex(0), dumpCaptureIndex(0), numKnownTextures(0), foundKnownTextures(0), skippedPresents(0), areaScale(1) {
 		#define TEXTURE(_name, _hash) ++numKnownTextures;
 		#include "Textures.def"
 		#undef TEXTURE
@@ -195,4 +196,6 @@ public:
 	HRESULT redirectSetRenderState(D3DRENDERSTATETYPE State, DWORD Value);
 	HRESULT redirectCreatePixelShader(CONST DWORD *pfunction, IDirect3DPixelShader9 **ppShader);
 	HRESULT redirectCreateVertexShader(CONST DWORD *pfunction, IDirect3DVertexShader9 **ppShader);
+
+	float getAreaScale() const { return areaScale; }
 };

--- a/d3d9.h
+++ b/d3d9.h
@@ -9,5 +9,6 @@
 #include <d3dx9.h>
 #include "d3d9int.h"
 #include "d3d9dev.h"
+#include "d3d9query.h"
 
 IDirect3D9 *APIENTRY hkDirect3DCreate9(UINT SDKVersion);

--- a/d3d9dev.cpp
+++ b/d3d9dev.cpp
@@ -186,7 +186,12 @@ HRESULT APIENTRY hkIDirect3DDevice9::CreatePixelShader(CONST DWORD* pFunction,ID
 }
 
 HRESULT APIENTRY hkIDirect3DDevice9::CreateQuery(D3DQUERYTYPE Type,IDirect3DQuery9** ppQuery) {
-	return m_pD3Ddev->CreateQuery(Type, ppQuery);
+	auto result = m_pD3Ddev->CreateQuery(Type, ppQuery);
+	if (Type == D3DQUERYTYPE_OCCLUSION && result == D3D_OK) {
+		new hkIDirect3DQuery9(ppQuery);
+		// These instances will leak, but there are only a set number of them created
+	}
+	return result;
 }
 
 HRESULT APIENTRY hkIDirect3DDevice9::CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle) {

--- a/d3d9query.cpp
+++ b/d3d9query.cpp
@@ -1,0 +1,46 @@
+#include "d3d9.h"
+#include "main.h"
+#include "RenderstateManager.h"
+#include "Settings.h"
+
+hkIDirect3DQuery9::hkIDirect3DQuery9(IDirect3DQuery9 **ppReturnedQueryInterface) {
+	m_pD3Dquery = *ppReturnedQueryInterface;
+	*ppReturnedQueryInterface = this;
+}
+
+HRESULT APIENTRY hkIDirect3DQuery9::QueryInterface(REFIID riid, void** ppvObj) {
+	return m_pD3Dquery->QueryInterface(riid, ppvObj);
+}
+
+ULONG APIENTRY hkIDirect3DQuery9::AddRef() {
+	return m_pD3Dquery->AddRef();
+}
+
+ULONG APIENTRY hkIDirect3DQuery9::Release() {
+	return m_pD3Dquery->Release();
+}
+
+HRESULT APIENTRY hkIDirect3DQuery9::GetDevice(IDirect3DDevice9** ppDevice) {
+	return m_pD3Dquery->GetDevice(ppDevice);
+}
+
+D3DQUERYTYPE APIENTRY hkIDirect3DQuery9::GetType() {
+	return m_pD3Dquery->GetType();
+}
+
+DWORD APIENTRY hkIDirect3DQuery9::GetDataSize() {
+	return m_pD3Dquery->GetDataSize();
+}
+
+HRESULT APIENTRY hkIDirect3DQuery9::Issue(DWORD dwIssueFlags) {
+	return m_pD3Dquery->Issue(dwIssueFlags);
+}
+
+HRESULT APIENTRY hkIDirect3DQuery9::GetData(void* pData, DWORD dwSize, DWORD dwGetDataFlags) {
+	auto result = m_pD3Dquery->GetData(pData, dwSize, dwGetDataFlags);
+	if (result == D3D_OK) {
+		auto pixelsDrawn = reinterpret_cast<DWORD*>(pData);
+		pixelsDrawn[0] = static_cast<DWORD>(pixelsDrawn[0] / RSManager::get().getAreaScale());
+	}
+	return result;
+}

--- a/d3d9query.cpp
+++ b/d3d9query.cpp
@@ -38,9 +38,9 @@ HRESULT APIENTRY hkIDirect3DQuery9::Issue(DWORD dwIssueFlags) {
 
 HRESULT APIENTRY hkIDirect3DQuery9::GetData(void* pData, DWORD dwSize, DWORD dwGetDataFlags) {
 	auto result = m_pD3Dquery->GetData(pData, dwSize, dwGetDataFlags);
-	if (result == D3D_OK) {
+	if (SUCCEEDED(result)) {
 		auto pixelsDrawn = reinterpret_cast<DWORD*>(pData);
-		pixelsDrawn[0] = static_cast<DWORD>(pixelsDrawn[0] / RSManager::get().getAreaScale());
+		pixelsDrawn[0] = static_cast<DWORD>(pixelsDrawn[0] / RSManager::get().getOcclusionScale());
 	}
 	return result;
 }

--- a/d3d9query.h
+++ b/d3d9query.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "d3d9.h"
+
+interface hkIDirect3DQuery9 : public IDirect3DQuery9
+{
+	hkIDirect3DQuery9(IDirect3DQuery9 **ppReturnedQueryInterface);
+
+	IDirect3DQuery9* m_pD3Dquery;
+
+	STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj);
+	STDMETHOD_(ULONG, AddRef)(THIS);
+	STDMETHOD_(ULONG, Release)(THIS);
+	STDMETHOD(GetDevice)(THIS_ IDirect3DDevice9** ppDevice);
+	STDMETHOD_(D3DQUERYTYPE, GetType)(THIS);
+	STDMETHOD_(DWORD, GetDataSize)(THIS);
+	STDMETHOD(Issue)(THIS_ DWORD dwIssueFlags);
+	STDMETHOD(GetData)(THIS_ void* pData, DWORD dwSize, DWORD dwGetDataFlags);
+};


### PR DESCRIPTION
Whether the sun and lens flares are drawn are determined by the result of
an occlusion query. If the query returns a larger number of pixels drawn
than expected, which often happens when running in a higher resolution
than the default, the sun and lens flares might not be drawn.

This change wraps the IDirect3DQuery9 objects used for occlusion queries
and modifies the returned number of pixels drawn to correspond with the
default resolution, which makes the sun and lens flares appear as
expected.