### PR TITLE
Texture dumping fixes

### DIFF
--- a/DATA/DSfix.ini
+++ b/DATA/DSfix.ini
@@ -184,7 +184,7 @@ maxBackups 10
 
 # enables texture dumping
 # you *only* need this if you want to create your own override textures
-# textures will be dumped to "dsfix\tex_override\[hash].tga"
+# textures will be dumped to "dsfix\tex_dump\[hash].tga"
 enableTextureDumping 0
 
 # enables texture override

--- a/main.cpp
+++ b/main.cpp
@@ -81,7 +81,7 @@ bool WINAPI DllMain(HMODULE hDll, DWORD dwReason, PVOID pvReserved) {
 }
 
 char *GetDirectoryFile(const char *filename) {
-	thread_local static char path[320];
+	__declspec( thread ) static char path[320];
 	strcpy_s(path, dlldir);
 	strcat_s(path, filename);
 	return path;

--- a/main.cpp
+++ b/main.cpp
@@ -81,7 +81,7 @@ bool WINAPI DllMain(HMODULE hDll, DWORD dwReason, PVOID pvReserved) {
 }
 
 char *GetDirectoryFile(const char *filename) {
-	static char path[320];
+	thread_local static char path[320];
 	strcpy_s(path, dlldir);
 	strcat_s(path, filename);
 	return path;


### PR DESCRIPTION
When texture dumping was enabled, it could lead to .fx-files being overwritten. This change fixes the problem and corrects an .ini-file comment.