### PR TITLE
Fix crash when enabling in-game AA

### DIFF
--- a/RenderstateManager.cpp
+++ b/RenderstateManager.cpp
@@ -321,7 +321,7 @@ HRESULT RSManager::redirectSetRenderTarget(DWORD RenderTargetIndex, IDirect3DSur
 						d3ddev->StretchRect(rgbaBuffer1Surf, NULL, oldRenderTarget, NULL, D3DTEXF_NONE);
 					}
 					restoreRenderState();
-					zTex->Release();
+					SAFERELEASE(zTex);
 					//if(takeScreenshot) D3DXSaveSurfaceToFile("1effect_buff.bmp", D3DXIFF_BMP, rgbaBuffer1Surf, NULL, NULL);
 					//if(takeScreenshot) D3DXSaveSurfaceToFile("1effect_post.bmp", D3DXIFF_BMP, oldRenderTarget, NULL, NULL);
 				}


### PR DESCRIPTION
This change fixes a crash that could occur when enabling AA in the in-game menu.

In-game AA still does not work with DSfix though, and should be disabled.